### PR TITLE
H2-1424 inject arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-buildium",
-  "version": "2.2.0",
+  "version": "2.2.1-calvinmceachron.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-buildium",
-  "version": "2.2.1-calvinmceachron.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-buildium",
   "description": "Custom eslint rules in use at Buildium",
   "repository": "https://github.com/buildium/eslint-plugin-buildium",
-  "version": "2.2.1-calvinmceachron.0",
+  "version": "2.2.1",
   "main": "index.js",
   "author": "Jeff Balboni <jeff.balboni@buildium.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-buildium",
   "description": "Custom eslint rules in use at Buildium",
   "repository": "https://github.com/buildium/eslint-plugin-buildium",
-  "version": "2.2.0",
+  "version": "2.2.1-calvinmceachron.0",
   "main": "index.js",
   "author": "Jeff Balboni <jeff.balboni@buildium.com>",
   "license": "MIT",

--- a/rules/angular-strict-di/angular-strict-di.test.js
+++ b/rules/angular-strict-di/angular-strict-di.test.js
@@ -148,7 +148,25 @@ new RuleTester({
             someModule.controller('MyController', ['$scope', 'greeter', function MyController($scope, greeter) {
             }]);
             `
-        }
+        },
+        {
+            code: `
+                const component = {};
+                component.controller = function ValidControllerAssignedToProperty($q) {
+
+                }
+            `,
+            errors: [
+                { message: new RegExp('is not using explicit annotation and cannot be invoked in strict mode') }
+            ],
+            output: `
+                const component = {};
+                component.controller = function ValidControllerAssignedToProperty($q) {
+
+                }
+                component.controller.$inject = ['$q'];
+            `,
+        },
     ],
 
     valid: [

--- a/rules/angular-strict-di/angular-strict-di.test.js
+++ b/rules/angular-strict-di/angular-strict-di.test.js
@@ -188,6 +188,15 @@ new RuleTester({
                 }
             `,
             options: [{ inlineArray: true }]
-        }
+        },
+        {
+            code: `
+                const component = {};
+                component.controller = function ValidControllerAssignedToProperty($q) {
+
+                };
+                component.controller.$inject = ['$q'];
+            `
+        },
     ],
 });

--- a/rules/angular-strict-di/angular-strict-di.test.js
+++ b/rules/angular-strict-di/angular-strict-di.test.js
@@ -152,7 +152,7 @@ new RuleTester({
         {
             code: `
                 const component = {};
-                component.controller = function ValidControllerAssignedToProperty($q) {
+                component.controller = function InvalidControllerAssignedToProperty($q) {
 
                 }
             `,
@@ -161,7 +161,7 @@ new RuleTester({
             ],
             output: `
                 const component = {};
-                component.controller = function ValidControllerAssignedToProperty($q) {
+                component.controller = function InvalidControllerAssignedToProperty($q) {
 
                 }
                 component.controller.$inject = ['$q'];
@@ -193,9 +193,9 @@ new RuleTester({
             code: `
                 function validMethodNoInjectables(param1, param2) {}
 
-                export function ValidControllerWithInjectable(MyService) {
+                export function ValidControllerWithInjectable2(MyService) {
                 };
-                ValidControllerWithInjectable.$inject = ['MyService'];
+                ValidControllerWithInjectable2.$inject = ['MyService'];
             `,
         },
         {
@@ -214,6 +214,14 @@ new RuleTester({
 
                 };
                 component.controller.$inject = ['$q'];
+            `
+        },
+        {
+            code: `
+                const controller = function ValidControllerAssignedToVariable($window) {
+
+                };
+                controller.$inject = ['$window'];
             `
         },
     ],


### PR DESCRIPTION
We were falsely reporting functions assigned to properties as not having $inject arrays, e.g.

```
const ctrl = function MyController($window) {}
ctrl.$inject = ['$window'];
```

where the rule was expecting 
```
const ctrl = function MyController($window) {}
MyController.$inject = ['$window'];
```

this corrects that bug and adds an autofix for the scenario where the $inject array is actually missing